### PR TITLE
INT-145 Helper functies toevoegen

### DIFF
--- a/database/factories/MenuItemFactory.php
+++ b/database/factories/MenuItemFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Made\Cms\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Made\Cms\Website\Models\MenuItem;
+
+class MenuItemFactory extends Factory
+{
+    protected $model = MenuItem::class;
+
+    public function definition(): array
+    {
+        return [
+            'location' => $this->faker->word(),
+            'link' => $this->faker->url(),
+            'label' => $this->faker->word(),
+            'title' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -142,6 +142,9 @@ class Cms
         return url($route->route, $parameters, $secure);
     }
 
+    /**
+     * Gather the menu items from a menu location.
+     */
     public function navigationItems(string $location): Collection
     {
         $menuItems = MenuItem::query()

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -14,6 +14,7 @@ use Made\Cms\Shared\Contracts\RouteableContract;
 use Made\Cms\Shared\Database\HasDatabaseTablePrefix;
 use Made\Cms\Shared\Models\Route;
 use Made\Cms\Website\Http\Controllers\NotFoundPageController;
+use Made\Cms\Website\Models\MenuItem;
 use Made\Cms\Website\Models\Settings\WebsiteSetting;
 
 class Cms
@@ -139,6 +140,17 @@ class Cms
         }
 
         return url($route->route, $parameters, $secure);
+    }
+
+    public function navigationItems(string $location): Collection
+    {
+        $menuItems = MenuItem::query()
+            ->fromLocation($location)
+            ->onlyMainItems()
+            ->orderBy('index', 'ASC')
+            ->get();
+
+        return $menuItems;
     }
 
     /**

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -148,8 +148,7 @@ class Cms
      * Gather the menu items from a menu location.
      *
      * @param  string  $location  The menu location from which you want to get the menu items.
-     *
-     * @return  Collection  Collection of the menu items.
+     * @return Collection Collection of the menu items.
      */
     public function navigationItems(string $location): Collection
     {

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Made\Cms;
 
 use Illuminate\Support\Collection;
@@ -21,7 +23,7 @@ class Cms
 {
     use HasDatabaseTablePrefix;
 
-    public const string VERSION = '0.8.0';
+    public const string VERSION = '0.11.3';
 
     public const string ALL_ROUTES = 'all';
 
@@ -144,12 +146,17 @@ class Cms
 
     /**
      * Gather the menu items from a menu location.
+     *
+     * @param  string  $location  The menu location from which you want to get the menu items.
+     *
+     * @return  Collection  Collection of the menu items.
      */
     public function navigationItems(string $location): Collection
     {
         $menuItems = MenuItem::query()
             ->fromLocation($location)
             ->onlyMainItems()
+            ->with(['children', 'linkable'])
             ->orderBy('index', 'ASC')
             ->get();
 

--- a/src/Facades/Cms.php
+++ b/src/Facades/Cms.php
@@ -5,10 +5,11 @@ namespace Made\Cms\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static string renderContentStrips(array $content)
- * @method static array localeOptions($disabled = true)
- *
- * @extends \Made\Cms\Cms
+ * @method static string renderContentStrips(array $content) Renders the content strips into an HTML string.
+ * @method static void routes(string $selection = 'all') Configures the routes for the application based on the provided selection.
+ * @method static string url(RouteableContract|Route $route, array $parameters = [], ?bool $secure = null) Generates a URL based on the given parameters.
+ * 
+ * @mixin \Made\Cms\Cms
  */
 class Cms extends Facade
 {

--- a/src/Facades/Cms.php
+++ b/src/Facades/Cms.php
@@ -2,8 +2,8 @@
 
 namespace Made\Cms\Facades;
 
-use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static string renderContentStrips(array $content) Renders the content strips into an HTML string.

--- a/src/Facades/Cms.php
+++ b/src/Facades/Cms.php
@@ -3,11 +3,13 @@
 namespace Made\Cms\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Collection;
 
 /**
  * @method static string renderContentStrips(array $content) Renders the content strips into an HTML string.
  * @method static void routes(string $selection = 'all') Configures the routes for the application based on the provided selection.
  * @method static string url(RouteableContract|Route $route, array $parameters = [], ?bool $secure = null) Generates a URL based on the given parameters.
+ * @method static Collection navigationItems(string $location) Gather the menu items from a menu location.
  *
  * @mixin \Made\Cms\Cms
  */

--- a/src/Shared/Models/Route.php
+++ b/src/Shared/Models/Route.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Made\Cms\Shared\Models;
 
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
+use Made\Cms\Database\Factories\RouteFactory;
 use Made\Cms\Page\Models\Page;
 use Made\Cms\Shared\Database\HasDatabaseTablePrefix;
 use Made\Cms\Shared\Observers\RouteObserver;
@@ -20,11 +22,14 @@ use Made\Cms\Shared\Observers\RouteObserver;
  * @property-read Carbon $created_at
  * @property-read Carbon $updated_at
  * @property-read Page $routeable
+ * 
+ * @method static RouteFactory factory()
  */
 #[ObservedBy(RouteObserver::class)]
 class Route extends Model
 {
     use HasDatabaseTablePrefix;
+    use HasFactory;
 
     protected $fillable = [
         'route',
@@ -53,5 +58,10 @@ class Route extends Model
     public function routeable(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    protected static function newFactory(): RouteFactory
+    {
+        return RouteFactory::new();
     }
 }

--- a/src/Website/Builders/MenuItemBuilder.php
+++ b/src/Website/Builders/MenuItemBuilder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Made\Cms\Website\Builders;
+
+use Illuminate\Database\Eloquent\Builder;
+
+class MenuItemBuilder extends Builder
+{
+    public function fromLocation(string $location): self
+    {
+        return $this->where('location', $location);
+    }
+
+    public function onlyMainItems(): self
+    {
+        return $this->whereNull('parent_id');
+    }
+}

--- a/src/Website/Models/MenuItem.php
+++ b/src/Website/Models/MenuItem.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Made\Cms\Website\Models;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
+use Made\Cms\Database\Factories\MenuItemFactory;
 use Made\Cms\Shared\Database\HasDatabaseTablePrefix;
 use Made\Cms\Website\Builders\MenuItemBuilder;
 
@@ -33,6 +35,7 @@ use Made\Cms\Website\Builders\MenuItemBuilder;
 class MenuItem extends Model
 {
     use HasDatabaseTablePrefix;
+    use HasFactory;
 
     public const string TABLE_NAME = 'menu_items';
 
@@ -125,5 +128,10 @@ class MenuItem extends Model
     public function newEloquentBuilder($query): MenuItemBuilder
     {
         return new MenuItemBuilder($query);
+    }
+
+    protected static function newFactory(): MenuItemFactory
+    {
+        return MenuItemFactory::new();
     }
 }

--- a/src/Website/Models/MenuItem.php
+++ b/src/Website/Models/MenuItem.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
 use Made\Cms\Shared\Database\HasDatabaseTablePrefix;
+use Made\Cms\Website\Builders\MenuItemBuilder;
 
 /**
  * @property-read int $id
@@ -26,6 +27,8 @@ use Made\Cms\Shared\Database\HasDatabaseTablePrefix;
  * @property int $index
  * @property-read Carbon $created_at
  * @property-read Carbon $updated_at
+ * 
+ * @method static MenuItemBuilder query()
  */
 class MenuItem extends Model
 {
@@ -114,5 +117,13 @@ class MenuItem extends Model
     public function getTable(): string
     {
         return $this->prefixTableName(self::TABLE_NAME);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function newEloquentBuilder($query): MenuItemBuilder
+    {
+        return new MenuItemBuilder($query);
     }
 }

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -57,7 +57,7 @@ class CmsTest extends TestCase
             MenuItem::factory()
                 ->for(Page::factory(), 'linkable')
                 ->create([
-                    'location' => 'main'
+                    'location' => 'main',
                 ]);
         }
 

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Made\Cms\Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Made\Cms\Facades\Cms;
+use Made\Cms\Page\Models\Page;
+use Made\Cms\Tests\TestCase;
+use Made\Cms\Website\Models\Settings\WebsiteSetting;
+use PHPUnit\Framework\Attributes\Test;
+
+class CmsTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    #[Test]
+    public function it_generates_an_url_from_a_route(): void
+    {
+        $page = Page::factory()->create();
+        $page->refresh();
+        
+        $this->assertSame(url($page->route->route), Cms::url($page->route));
+    }
+
+    #[Test]
+    public function it_generates_an_url_from_a_routeable_model(): void
+    {
+        $page = Page::factory()->create();
+        $page->refresh();
+        
+        $this->assertSame(url($page->route->route), Cms::url($page));
+    }
+
+    #[Test]
+    public function it_generates_an_empty_url_when_the_given_model_is_the_landing_page(): void
+    {
+        $page = Page::factory()->create();
+        $page->refresh();
+
+        $websiteSetting = new WebsiteSetting();
+
+        $websiteSetting->landing_page = $page->id;
+        $websiteSetting->save();
+        
+        $this->assertSame(url('/'), Cms::url($page));
+    }
+}

--- a/tests/Unit/CmsTest.php
+++ b/tests/Unit/CmsTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Made\Cms\Facades\Cms;
 use Made\Cms\Page\Models\Page;
 use Made\Cms\Tests\TestCase;
+use Made\Cms\Website\Models\MenuItem;
 use Made\Cms\Website\Models\Settings\WebsiteSetting;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -45,5 +46,39 @@ class CmsTest extends TestCase
         $websiteSetting->save();
 
         $this->assertSame(url('/'), Cms::url($page));
+    }
+
+    #[Test]
+    public function it_can_return_the_menu_items_of_a_menu_location(): void
+    {
+        $randomInt = random_int(0, 8);
+
+        for ($i = 0; $i < $randomInt; $i++) {
+            MenuItem::factory()
+                ->for(Page::factory(), 'linkable')
+                ->create([
+                    'location' => 'main'
+                ]);
+        }
+
+        $items = Cms::navigationItems('main');
+
+        $this->assertSame($randomInt, $items->count());
+
+        $menuItem = MenuItem::inRandomOrder()->first();
+
+        MenuItem::factory()
+            ->for(Page::factory(), 'linkable')
+            ->create([
+                'location' => 'main',
+                'parent_id' => $menuItem->id,
+            ]);
+
+        $items = Cms::navigationItems('main');
+
+        $selectedItem = $items->filter(fn ($item) => $item->id === $menuItem->id)->first();
+
+        $this->assertSame($randomInt, $items->count());
+        $this->assertSame(1, $selectedItem->children->count());
     }
 }


### PR DESCRIPTION
Er moeten een aantal helper functies komen voor de front-end om mee te werken:

#### Todo:
- [x] **Route / Url helper**
Hiermee moet het makkelijker worden om per model een url te genereren. Deze method houdt ook rekening met het feit dat een pagina bijvoorbeeld een landingspagina is en geeft dan alleen een / terug.
- [x] **Getter voor menu items**
Deze methode moet ervoor zorgen dat je aan de hand van een menu key de menu items kunt ophalen en deze via een foreach kunt genereren.