### PR TITLE
Adds privacy & cookie statement page settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,8 @@
                 "Made\\Cms\\Providers\\CmsPanelServiceProvider"
             ],
             "aliases": {
-                "Cms": "Made\\Cms\\Facades\\Cms"
+                "Cms": "Made\\Cms\\Facades\\Cms",
+                "Made": "Made\\Cms\\Facades\\Made"
             }
         }
     },

--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -55,6 +55,18 @@ return [
 
         'pages' => [],
 
+        /**
+         * ### Custom link types
+         * _____
+         * 
+         * These custom link types make it possible to add link types to the url selection within 
+         * the CMS. So when you add custom resources and models you can add them to the link 
+         * selection this way.
+         * 
+         * @var array<string, class-string<RouteableContract>>
+         */
+        'custom_link_types' => [],
+
     ],
 
     /**

--- a/database/settings/2025_05_13_113505_add_statement_page_selection_web_settings.php
+++ b/database/settings/2025_05_13_113505_add_statement_page_selection_web_settings.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        if ($this->migrator->exists('web.privacy_policy_page')) {
+            return;
+        }
+
+        $this->migrator->add('web.privacy_policy_page');
+        $this->migrator->add('web.cookie_statement_page');
+
+    }
+};

--- a/resources/lang/en/cms.php
+++ b/resources/lang/en/cms.php
@@ -560,7 +560,7 @@ return [
                     ],
                     'statements' => [
                         'title' => 'Statements',
-                        'description' => "Here you can find all settings regarding data and security statements surrounding the website.",
+                        'description' => 'Here you can find all settings regarding data and security statements surrounding the website.',
                     ],
                 ],
             ],

--- a/resources/lang/en/cms.php
+++ b/resources/lang/en/cms.php
@@ -535,6 +535,14 @@ return [
                         'label' => 'Select a not found page',
                         'helperText' => 'Select a page to be displayed as soon as nothing can be found to display.',
                     ],
+                    'privacy_policy_page' => [
+                        'label' => 'Select a privacy statement page',
+                        'helperText' => 'Select here the page containing the website\'s privacy statement.',
+                    ],
+                    'cookie_statement_page' => [
+                        'label' => 'Select a cookie statement page',
+                        'helperText' => 'Select here the page containing the cookie statements of the website.',
+                    ],
                 ],
 
                 'sections' => [
@@ -549,6 +557,10 @@ return [
                     'menulocations' => [
                         'title' => 'Menu locations',
                         'description' => 'Manage menu locations here which are used to populate navigation menus and display them in certain places in the website.',
+                    ],
+                    'statements' => [
+                        'title' => 'Statements',
+                        'description' => "Here you can find all settings regarding data and security statements surrounding the website.",
                     ],
                 ],
             ],

--- a/resources/lang/nl/cms.php
+++ b/resources/lang/nl/cms.php
@@ -532,6 +532,14 @@ return [
                         'label' => 'Selecteer een niet gevonden pagina',
                         'helperText' => 'Selecteer een pagina welke wordt getoond zodra er niks kan worden gevonden om te tonen.',
                     ],
+                    'privacy_policy_page' => [
+                        'label' => 'Selecteer een privacy verklarings pagina',
+                        'helperText' => 'Selecteer hier de pagina welke de privacy verklaring van de website bevat.',
+                    ],
+                    'cookie_statement_page' => [
+                        'label' => 'Selecteer een cookieverklaring pagina',
+                        'helperText' => 'Selecteer hier de pagina welke de cookie verklaringen van de website bevat.',
+                    ],
                 ],
 
                 'sections' => [
@@ -546,6 +554,10 @@ return [
                     'menulocations' => [
                         'title' => 'Menu locaties',
                         'description' => 'Beheer hier de menu locaties welke worden gebruikt om navigatie menu\'s te vullen en op bepaalde plekken in de website te tonen.',
+                    ],
+                    'statements' => [
+                        'title' => 'Verklaringen',
+                        'description' => "Hier kun je alle instellingen vinden wat betreft de verklaringen van gegevens en veiligheid rondom de website.",
                     ],
                 ],
             ],

--- a/resources/lang/nl/cms.php
+++ b/resources/lang/nl/cms.php
@@ -557,7 +557,7 @@ return [
                     ],
                     'statements' => [
                         'title' => 'Verklaringen',
-                        'description' => "Hier kun je alle instellingen vinden wat betreft de verklaringen van gegevens en veiligheid rondom de website.",
+                        'description' => 'Hier kun je alle instellingen vinden wat betreft de verklaringen van gegevens en veiligheid rondom de website.',
                     ],
                 ],
             ],

--- a/src/Cms.php
+++ b/src/Cms.php
@@ -23,7 +23,7 @@ class Cms
 {
     use HasDatabaseTablePrefix;
 
-    public const string VERSION = '0.14.0';
+    public const string VERSION = '0.14.3';
 
     public const string ALL_ROUTES = 'all';
 

--- a/src/Facades/Made.php
+++ b/src/Facades/Made.php
@@ -14,7 +14,7 @@ use Made\Cms\Made as CmsMade;
 class Made extends Facade
 {
     public const LINK_TYPE_PAGES = CmsMade::LINK_TYPE_PAGES;
-    
+
     public const LINK_TYPE_POSTS = CmsMade::LINK_TYPE_POSTS;
 
     protected static function getFacadeAccessor(): string

--- a/src/Facades/Made.php
+++ b/src/Facades/Made.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace Made\Cms\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Made\Cms\Made as CmsMade;
 
 /**
  * @method static array madeLinkOptions(?array $selected = null)
+ * @method static RouteableContract|null modelFromSelection(string $selection)
  */
 class Made extends Facade
 {
-    public const LINK_TYPE_PAGES = 'pages';
-    public const LINK_TYPE_POSTS = 'posts';
+    public const LINK_TYPE_PAGES = CmsMade::LINK_TYPE_PAGES;
+    public const LINK_TYPE_POSTS = CmsMade::LINK_TYPE_POSTS;
 
     protected static function getFacadeAccessor(): string
     {

--- a/src/Facades/Made.php
+++ b/src/Facades/Made.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Made\Cms\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static array madeLinkOptions(?array $selected = null)
+ */
+class Made extends Facade
+{
+    public const LINK_TYPE_PAGES = 'pages';
+    public const LINK_TYPE_POSTS = 'posts';
+
+    protected static function getFacadeAccessor(): string
+    {
+        return \Made\Cms\Made::class;
+    }
+}

--- a/src/Made.php
+++ b/src/Made.php
@@ -12,8 +12,8 @@ class Made
 {
     public const string VERSION = '0.14.3';
 
-    public const LINK_TYPE_PAGES = 'pages';
-    public const LINK_TYPE_POSTS = 'posts';
+    public const LINK_TYPE_PAGES = 'page';
+    public const LINK_TYPE_POSTS = 'post';
 
     public function madeLinkOptions(?array $selected = null): array
     {
@@ -44,6 +44,31 @@ class Made
 
         return $options;
     }
+    
+    /**
+     * Get the model from the selection string.
+     *
+     * @param string $selection The selection string in the format "type:id".
+     * @return RouteableContract|null The model instance or null if not found.
+     */
+    public function modelFromSelection(string $selection): ?RouteableContract
+    {
+        $parts = explode(':', $selection);
+
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        [$type, $id] = $parts;
+
+        $types = $this->getLinkTypes();
+
+        if (!array_key_exists($type, $types)) {
+            return null;
+        }
+
+        return $types[$type]::findOrFail($id);
+    }
 
     /**
      * @return array<string, class-string<RouteableContract>>
@@ -53,8 +78,8 @@ class Made
         $customTypes = config('made-cms.panel.custom_link_types', []);
 
         return [
-            'pages' => Page::class,
-            'posts' => Post::class,
+            self::LINK_TYPE_PAGES => Page::class,
+            self::LINK_TYPE_POSTS => Post::class,
 
             ...$customTypes,
         ];

--- a/src/Made.php
+++ b/src/Made.php
@@ -45,11 +45,11 @@ class Made
 
         return $options;
     }
-    
+
     /**
      * Get the model from the selection string.
      *
-     * @param string $selection The selection string in the format "type:id".
+     * @param  string  $selection  The selection string in the format "type:id".
      * @return RouteableContract|null The model instance or null if not found.
      */
     public function modelFromSelection(string $selection): ?RouteableContract
@@ -64,7 +64,7 @@ class Made
 
         $types = $this->getLinkTypes();
 
-        if (!array_key_exists($type, $types)) {
+        if (! array_key_exists($type, $types)) {
             return null;
         }
 

--- a/src/Made.php
+++ b/src/Made.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Made\Cms;
+
+use Made\Cms\News\Models\Post;
+use Made\Cms\Page\Models\Page;
+use Made\Cms\Shared\Contracts\RouteableContract;
+
+class Made
+{
+    public const string VERSION = '0.14.3';
+
+    public const LINK_TYPE_PAGES = 'pages';
+    public const LINK_TYPE_POSTS = 'posts';
+
+    public function madeLinkOptions(?array $selected = null): array
+    {
+        $types = $this->getLinkTypes();
+        $options = [];
+
+        if (!empty($selected)) {
+            $types = array_filter(
+                $types,
+                fn ($key) => in_array($key, $selected, true),
+                ARRAY_FILTER_USE_KEY,
+            );
+        }
+
+        foreach ($types as $type) {
+            if (is_subclass_of($type, RouteableContract::class)) {
+                $entries = $type::query()
+                    ->forLinkSelection()
+                    ->get();
+
+                $options[$entries->first()->linkGroupName()] = $entries->mapWithKeys(
+                    fn (RouteableContract $route) => [
+                        $route->linkKey().':'.$route->getKey() => $route->linkName()
+                    ], 
+                )->toArray();
+            }
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return array<string, class-string<RouteableContract>>
+     */
+    protected function getLinkTypes(): array
+    {
+        $customTypes = config('made-cms.panel.custom_link_types', []);
+
+        return [
+            'pages' => Page::class,
+            'posts' => Post::class,
+
+            ...$customTypes,
+        ];
+    }
+}

--- a/src/News/Models/Post.php
+++ b/src/News/Models/Post.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Made\Cms\News\Models;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -195,6 +196,38 @@ class Post extends Model implements DefinesCreatedByContract, HasMedia, HasMeta,
         $parts[] = $this->slug;
 
         return $parts;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function linkName(): string
+    {
+        return $this->getAttribute('name');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function linkKey(): string
+    {
+        return 'post';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function linkGroupName(): string
+    {
+        return __('made-cms::cms.resources.post.label');
+    }
+
+    /** 
+     * @inheritDoc
+     */
+    public function scopeForLinkSelection(PostQueryBuilder|Builder $query): PostQueryBuilder
+    {
+        return $query->published();
     }
 
     /**

--- a/src/Page/Models/Page.php
+++ b/src/Page/Models/Page.php
@@ -4,6 +4,7 @@ namespace Made\Cms\Page\Models;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -228,6 +229,40 @@ class Page extends Model implements DefinesCreatedByContract, HasMeta, Routeable
     public function getTable(): string
     {
         return $this->prefixTableName('pages');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function linkName(): string
+    {
+        return $this->getAttribute('name');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function linkKey(): string
+    {
+        return 'page';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function linkGroupName(): string
+    {
+        return __('made-cms::cms.resources.page.label');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function scopeForLinkSelection(PageQueryBuilder|Builder $query): PageQueryBuilder
+    {
+        return $query
+            ->select(['id', 'name'])
+            ->published();
     }
 
     /**

--- a/src/Shared/Contracts/RouteableContract.php
+++ b/src/Shared/Contracts/RouteableContract.php
@@ -2,11 +2,15 @@
 
 namespace Made\Cms\Shared\Contracts;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 /**
  * @extends Model
+ * 
+ * @method static Builder query()
+ * @method mixed getKey()
  */
 interface RouteableContract
 {
@@ -26,4 +30,26 @@ interface RouteableContract
      * @return array The array of URL parts including the slugs from the hierarchy.
      */
     public function urlSchema(array &$parts = []): array;
+
+    /**
+     * Returns the link name which can be presented within the link selection,
+     */
+    public function linkName(): string;
+    
+    /**
+     * Returns a key which will be added in front of the link selection option.
+     * 
+     * Example: page => page:1, post => post:1 etc.
+     */
+    public function linkKey(): string;
+
+    /**
+     * Returns the group name which will be used to group the link selection options.
+     */
+    public function linkGroupName(): string;
+
+    /**
+     * Selects the options which can be added to the link selects within Made.
+     */
+    public function scopeForLinkSelection(Builder $query): Builder;
 }

--- a/src/Website/Filament/Pages/WebsiteSettingsPage.php
+++ b/src/Website/Filament/Pages/WebsiteSettingsPage.php
@@ -90,8 +90,6 @@ class WebsiteSettingsPage extends SettingsPage
                     ])
                     ->columnSpan(4),
 
-
-
                 Section::make(__('made-cms::cms.resources.settings.website.sections.statements.title'))
                     ->description(__('made-cms::cms.resources.settings.website.sections.statements.description'))
                     ->aside()

--- a/src/Website/Filament/Pages/WebsiteSettingsPage.php
+++ b/src/Website/Filament/Pages/WebsiteSettingsPage.php
@@ -11,6 +11,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Pages\SettingsPage;
 use Illuminate\Contracts\Support\Htmlable;
+use Made\Cms\Facades\Made;
 use Made\Cms\Page\Models\Page;
 use Made\Cms\Website\Models\Settings\WebsiteSetting;
 
@@ -46,24 +47,14 @@ class WebsiteSettingsPage extends SettingsPage
                             ->label(__('made-cms::cms.resources.settings.website.fields.landing_page.label'))
                             ->helperText(__('made-cms::cms.resources.settings.website.fields.landing_page.helperText'))
                             ->options(
-                                fn () => Page::query()
-                                    ->published()
-                                    ->select(['id', 'name'])
-                                    ->get()
-                                    ->mapWithKeys(fn (Page $page) => [$page->id => $page->name])
-                                    ->toArray()
+                                Made::madeLinkOptions([Made::LINK_TYPE_PAGES])
                             ),
 
                         Select::make('not_found_page')
                             ->label(__('made-cms::cms.resources.settings.website.fields.not_found_page.label'))
                             ->helperText(__('made-cms::cms.resources.settings.website.fields.not_found_page.helperText'))
                             ->options(
-                                fn () => Page::query()
-                                    ->published()
-                                    ->select(['id', 'name'])
-                                    ->get()
-                                    ->mapWithKeys(fn (Page $page) => [$page->id => $page->name])
-                                    ->toArray()
+                                Made::madeLinkOptions([Made::LINK_TYPE_PAGES])
                             ),
 
                     ])

--- a/src/Website/Filament/Pages/WebsiteSettingsPage.php
+++ b/src/Website/Filament/Pages/WebsiteSettingsPage.php
@@ -91,6 +91,28 @@ class WebsiteSettingsPage extends SettingsPage
                     ])
                     ->columnSpan(4),
 
+
+
+                Section::make(__('made-cms::cms.resources.settings.website.sections.statements.title'))
+                    ->description(__('made-cms::cms.resources.settings.website.sections.statements.description'))
+                    ->aside()
+                    ->schema([
+                        Select::make('privacy_policy_page')
+                            ->label(__('made-cms::cms.resources.settings.website.fields.privacy_policy_page.label'))
+                            ->helperText(__('made-cms::cms.resources.settings.website.fields.privacy_policy_page.helperText'))
+                            ->options(
+                                Made::madeLinkOptions([Made::LINK_TYPE_PAGES])
+                            ),
+
+                        Select::make('cookie_statement_page')
+                            ->label(__('made-cms::cms.resources.settings.website.fields.cookie_statement_page.label'))
+                            ->helperText(__('made-cms::cms.resources.settings.website.fields.cookie_statement_page.helperText'))
+                            ->options(
+                                Made::madeLinkOptions([Made::LINK_TYPE_PAGES])
+                            ),
+                    ])
+                    ->columnSpan(4),
+
             ], ...$settings))
             ->columns(5);
     }

--- a/src/Website/Models/Settings/WebsiteSetting.php
+++ b/src/Website/Models/Settings/WebsiteSetting.php
@@ -78,12 +78,10 @@ class WebsiteSetting extends Settings
 
     /**
      * Retrieves the selected Page from the given key.
-     *
-     * @return Page|null 
      */
     public function getPage(string $key): ?Page
     {
-        if (!isset($this->{$key})) {
+        if (! isset($this->{$key})) {
             return null;
         }
 

--- a/src/Website/Models/Settings/WebsiteSetting.php
+++ b/src/Website/Models/Settings/WebsiteSetting.php
@@ -2,6 +2,7 @@
 
 namespace Made\Cms\Website\Models\Settings;
 
+use Made\Cms\Facades\Made;
 use Made\Cms\Page\Models\Page;
 use Spatie\LaravelSettings\Settings;
 
@@ -15,12 +16,17 @@ class WebsiteSetting extends Settings
     /**
      * Selected page id which will be used as the landing page.
      */
-    public ?int $landing_page = null;
+    public ?string $landing_page = null;
 
     /**
      * Selected page id which shows the privacy policy content.
      */
-    public ?int $privacy_policy_page = null;
+    public ?string $privacy_policy_page = null;
+
+    /**
+     * Selected page id which shows the cookie policy page.
+     */
+    public ?string $cookie_statement_page = null;
 
     /**
      * The menu locations that are available.
@@ -30,7 +36,7 @@ class WebsiteSetting extends Settings
     /**
      * The selected page ID which respresents the 404 Not Found page.
      */
-    public ?int $not_found_page = null;
+    public ?string $not_found_page = null;
 
     /**
      * Check if the website is online.
@@ -68,6 +74,26 @@ class WebsiteSetting extends Settings
         }
 
         return Page::findOrFail($this->not_found_page);
+    }
+
+    /**
+     * Retrieves the selected Page from the given key.
+     *
+     * @return Page|null 
+     */
+    public function getPage(string $key): ?Page
+    {
+        if (!isset($this->{$key})) {
+            return null;
+        }
+
+        $value = $this->{$key};
+
+        if (empty($value)) {
+            return null;
+        }
+
+        return Made::modelFromSelection($value);
     }
 
     /**

--- a/src/Website/Models/Settings/WebsiteSetting.php
+++ b/src/Website/Models/Settings/WebsiteSetting.php
@@ -18,6 +18,11 @@ class WebsiteSetting extends Settings
     public ?int $landing_page = null;
 
     /**
+     * Selected page id which shows the privacy policy content.
+     */
+    public ?int $privacy_policy_page = null;
+
+    /**
      * The menu locations that are available.
      */
     public array $menu_locations = ['default'];


### PR DESCRIPTION
Adds settings for selecting privacy policy and cookie statement pages in the CMS.

- Introduces new settings in the website settings page for selecting pages containing the privacy policy and cookie statements.
- Introduces a `Made` facade to retrieve models for link selections dynamically.
- Adds custom link type support to the CMS configuration.
- Updates translations for new settings and sections.
- Adds a new settings migration for the new settings.