### PR TITLE
✨ Adds introduction field to posts

### DIFF
--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -142,6 +142,10 @@ return [
                 //
             ],
         ],
+
+        'post' => [
+            'introduction_max_length' => env('MADE_CONTENT_POST_INTRODUCTION_MAX_LENGTH', 250),
+        ],
     ],
 
     'settings' => [

--- a/database/migrations/2025_05_16_100627_add_introduction_to_posts_table.php
+++ b/database/migrations/2025_05_16_100627_add_introduction_to_posts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Made\Cms\Shared\Database\HasDatabaseTablePrefix;
+
+return new class extends Migration
+{
+    use HasDatabaseTablePrefix;
+
+    public const string TABLE = 'posts';
+
+    public function up(): void
+    {
+        Schema::table($this->prefixTableName(self::TABLE), function (Blueprint $table) {
+            $table->text('introduction')
+                ->nullable()
+                ->after('date');
+        });
+    }
+};

--- a/resources/lang/en/cms.php
+++ b/resources/lang/en/cms.php
@@ -738,6 +738,10 @@ return [
                     'label' => 'Date of the news item',
                     'helperText' => 'This date can be shown with the message as the date of the news item. The order of the news is also determined by this date.',
                 ],
+                'introduction' => [
+                    'label' => 'Short introduction',
+                    'helperText' => 'This short introductory text is used in the overview of the news item.',
+                ],
                 'status' => [
                     'label' => 'Status',
                     'helperText' => 'This status of the post indicates what the post can be used for. Once the status is set to published, any visitor can view the post.',

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -1,0 +1,196 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => 'The :attribute field must be accepted.',
+    'accepted_if' => 'The :attribute field must be accepted when :other is :value.',
+    'active_url' => 'The :attribute field must be a valid URL.',
+    'after' => 'The :attribute field must be a date after :date.',
+    'after_or_equal' => 'The :attribute field must be a date after or equal to :date.',
+    'alpha' => 'The :attribute field must only contain letters.',
+    'alpha_dash' => 'The :attribute field must only contain letters, numbers, dashes, and underscores.',
+    'alpha_num' => 'The :attribute field must only contain letters and numbers.',
+    'array' => 'The :attribute field must be an array.',
+    'ascii' => 'The :attribute field must only contain single-byte alphanumeric characters and symbols.',
+    'before' => 'The :attribute field must be a date before :date.',
+    'before_or_equal' => 'The :attribute field must be a date before or equal to :date.',
+    'between' => [
+        'array' => 'The :attribute field must have between :min and :max items.',
+        'file' => 'The :attribute field must be between :min and :max kilobytes.',
+        'numeric' => 'The :attribute field must be between :min and :max.',
+        'string' => 'The :attribute field must be between :min and :max characters.',
+    ],
+    'boolean' => 'The :attribute field must be true or false.',
+    'can' => 'The :attribute field contains an unauthorized value.',
+    'confirmed' => 'The :attribute field confirmation does not match.',
+    'contains' => 'The :attribute field is missing a required value.',
+    'current_password' => 'The password is incorrect.',
+    'date' => 'The :attribute field must be a valid date.',
+    'date_equals' => 'The :attribute field must be a date equal to :date.',
+    'date_format' => 'The :attribute field must match the format :format.',
+    'decimal' => 'The :attribute field must have :decimal decimal places.',
+    'declined' => 'The :attribute field must be declined.',
+    'declined_if' => 'The :attribute field must be declined when :other is :value.',
+    'different' => 'The :attribute field and :other must be different.',
+    'digits' => 'The :attribute field must be :digits digits.',
+    'digits_between' => 'The :attribute field must be between :min and :max digits.',
+    'dimensions' => 'The :attribute field has invalid image dimensions.',
+    'distinct' => 'The :attribute field has a duplicate value.',
+    'doesnt_end_with' => 'The :attribute field must not end with one of the following: :values.',
+    'doesnt_start_with' => 'The :attribute field must not start with one of the following: :values.',
+    'email' => 'The :attribute field must be a valid email address.',
+    'ends_with' => 'The :attribute field must end with one of the following: :values.',
+    'enum' => 'The selected :attribute is invalid.',
+    'exists' => 'The selected :attribute is invalid.',
+    'extensions' => 'The :attribute field must have one of the following extensions: :values.',
+    'file' => 'The :attribute field must be a file.',
+    'filled' => 'The :attribute field must have a value.',
+    'gt' => [
+        'array' => 'The :attribute field must have more than :value items.',
+        'file' => 'The :attribute field must be greater than :value kilobytes.',
+        'numeric' => 'The :attribute field must be greater than :value.',
+        'string' => 'The :attribute field must be greater than :value characters.',
+    ],
+    'gte' => [
+        'array' => 'The :attribute field must have :value items or more.',
+        'file' => 'The :attribute field must be greater than or equal to :value kilobytes.',
+        'numeric' => 'The :attribute field must be greater than or equal to :value.',
+        'string' => 'The :attribute field must be greater than or equal to :value characters.',
+    ],
+    'hex_color' => 'The :attribute field must be a valid hexadecimal color.',
+    'image' => 'The :attribute field must be an image.',
+    'in' => 'The selected :attribute is invalid.',
+    'in_array' => 'The :attribute field must exist in :other.',
+    'integer' => 'The :attribute field must be an integer.',
+    'ip' => 'The :attribute field must be a valid IP address.',
+    'ipv4' => 'The :attribute field must be a valid IPv4 address.',
+    'ipv6' => 'The :attribute field must be a valid IPv6 address.',
+    'json' => 'The :attribute field must be a valid JSON string.',
+    'list' => 'The :attribute field must be a list.',
+    'lowercase' => 'The :attribute field must be lowercase.',
+    'lt' => [
+        'array' => 'The :attribute field must have less than :value items.',
+        'file' => 'The :attribute field must be less than :value kilobytes.',
+        'numeric' => 'The :attribute field must be less than :value.',
+        'string' => 'The :attribute field must be less than :value characters.',
+    ],
+    'lte' => [
+        'array' => 'The :attribute field must not have more than :value items.',
+        'file' => 'The :attribute field must be less than or equal to :value kilobytes.',
+        'numeric' => 'The :attribute field must be less than or equal to :value.',
+        'string' => 'The :attribute field must be less than or equal to :value characters.',
+    ],
+    'mac_address' => 'The :attribute field must be a valid MAC address.',
+    'max' => [
+        'array' => 'The :attribute field must not have more than :max items.',
+        'file' => 'The :attribute field must not be greater than :max kilobytes.',
+        'numeric' => 'The :attribute field must not be greater than :max.',
+        'string' => 'The :attribute field must not be greater than :max characters.',
+    ],
+    'max_digits' => 'The :attribute field must not have more than :max digits.',
+    'mimes' => 'The :attribute field must be a file of type: :values.',
+    'mimetypes' => 'The :attribute field must be a file of type: :values.',
+    'min' => [
+        'array' => 'The :attribute field must have at least :min items.',
+        'file' => 'The :attribute field must be at least :min kilobytes.',
+        'numeric' => 'The :attribute field must be at least :min.',
+        'string' => 'The :attribute field must be at least :min characters.',
+    ],
+    'min_digits' => 'The :attribute field must have at least :min digits.',
+    'missing' => 'The :attribute field must be missing.',
+    'missing_if' => 'The :attribute field must be missing when :other is :value.',
+    'missing_unless' => 'The :attribute field must be missing unless :other is :value.',
+    'missing_with' => 'The :attribute field must be missing when :values is present.',
+    'missing_with_all' => 'The :attribute field must be missing when :values are present.',
+    'multiple_of' => 'The :attribute field must be a multiple of :value.',
+    'not_in' => 'The selected :attribute is invalid.',
+    'not_regex' => 'The :attribute field format is invalid.',
+    'numeric' => 'The :attribute field must be a number.',
+    'password' => [
+        'letters' => 'The :attribute field must contain at least one letter.',
+        'mixed' => 'The :attribute field must contain at least one uppercase and one lowercase letter.',
+        'numbers' => 'The :attribute field must contain at least one number.',
+        'symbols' => 'The :attribute field must contain at least one symbol.',
+        'uncompromised' => 'The given :attribute has appeared in a data leak. Please choose a different :attribute.',
+    ],
+    'present' => 'The :attribute field must be present.',
+    'present_if' => 'The :attribute field must be present when :other is :value.',
+    'present_unless' => 'The :attribute field must be present unless :other is :value.',
+    'present_with' => 'The :attribute field must be present when :values is present.',
+    'present_with_all' => 'The :attribute field must be present when :values are present.',
+    'prohibited' => 'The :attribute field is prohibited.',
+    'prohibited_if' => 'The :attribute field is prohibited when :other is :value.',
+    'prohibited_if_accepted' => 'The :attribute field is prohibited when :other is accepted.',
+    'prohibited_if_declined' => 'The :attribute field is prohibited when :other is declined.',
+    'prohibited_unless' => 'The :attribute field is prohibited unless :other is in :values.',
+    'prohibits' => 'The :attribute field prohibits :other from being present.',
+    'regex' => 'The :attribute field format is invalid.',
+    'required' => 'The :attribute field is required.',
+    'required_array_keys' => 'The :attribute field must contain entries for: :values.',
+    'required_if' => 'The :attribute field is required when :other is :value.',
+    'required_if_accepted' => 'The :attribute field is required when :other is accepted.',
+    'required_if_declined' => 'The :attribute field is required when :other is declined.',
+    'required_unless' => 'The :attribute field is required unless :other is in :values.',
+    'required_with' => 'The :attribute field is required when :values is present.',
+    'required_with_all' => 'The :attribute field is required when :values are present.',
+    'required_without' => 'The :attribute field is required when :values is not present.',
+    'required_without_all' => 'The :attribute field is required when none of :values are present.',
+    'same' => 'The :attribute field must match :other.',
+    'size' => [
+        'array' => 'The :attribute field must contain :size items.',
+        'file' => 'The :attribute field must be :size kilobytes.',
+        'numeric' => 'The :attribute field must be :size.',
+        'string' => 'The :attribute field must be :size characters.',
+    ],
+    'starts_with' => 'The :attribute field must start with one of the following: :values.',
+    'string' => 'The :attribute field must be a string.',
+    'timezone' => 'The :attribute field must be a valid timezone.',
+    'unique' => 'The :attribute has already been taken.',
+    'uploaded' => 'The :attribute failed to upload.',
+    'uppercase' => 'The :attribute field must be uppercase.',
+    'url' => 'The :attribute field must be a valid URL.',
+    'ulid' => 'The :attribute field must be a valid ULID.',
+    'uuid' => 'The :attribute field must be a valid UUID.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [],
+
+];

--- a/resources/lang/nl/cms.php
+++ b/resources/lang/nl/cms.php
@@ -732,6 +732,10 @@ return [
                     'label' => 'Datum van het bericht',
                     'helperText' => 'Deze datum kan bij het bericht getoond worden als datum van het nieuwsbericht. De volgorde van het nieuws wordt ook aan de hand van deze datum bepaald.',
                 ],
+                'introduction' => [
+                    'label' => 'Korte inleiding',
+                    'helperText' => 'Deze korte inleidingstekst wordt gebruikt in het overzicht bij het nieuwsbericht.',
+                ],
                 'status' => [
                     'label' => 'Status',
                     'helperText' => 'Deze status van het nieuwsbericht geeft aan waarvoor het nieuwsbericht gebruikt kan worden. Zodra de status is ingesteld op gepubliceerd, kan elke bezoeker het nieuwsbericht bekijken.',

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -1,0 +1,184 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => ':Attribute dient te worden geaccepteerd.',
+    'accepted_if' => ':Attribute dient te worden geaccepteerd wanneer :other :value is.',
+    'active_url' => ':Attribute is geen geldige URL.',
+    'after' => ':Attribute moet een datum zijn na :date.',
+    'after_or_equal' => ':Attribute moet een datum zijn na of gelijk aan :date.',
+    'alpha' => ':Attribute mag alleen letters bevatten.',
+    'alpha_dash' => ':Attribute mag alleen letters, nummers, en strepen bevatten.',
+    'alpha_num' => ':Attribute mag alleen letters en nummers bevatten.',
+    'array' => ':Attribute moet een array zijn.',
+    'ascii' => ':Attribute mag alleen standaard karakters en cijfers bevatten',
+    'before' => ':Attribute moet een datum zijn eerder dan :date.',
+    'before_or_equal' => ':Attribute moet een datum zijn voor of gelijk aan :date.',
+    'between' => [
+        'numeric' => ':Attribute moet tussen :min en :max liggen.',
+        'file' => ':Attribute moet tussen :min en :max kilobytes zijn.',
+        'string' => ':Attribute moet tussen :min en :max karakters lang zijn.',
+        'array' => ':Attribute moet tussen :min en :max items bevatten.',
+    ],
+    'boolean' => ':Attribute kan enkel waar of niet waar zijn.',
+    'confirmed' => ':Attribute bevestiging komt niet overeen.',
+    'current_password' => 'Het wachtwoord is ongeldig.',
+    'date' => ':Attribute is geen geldige datum.',
+    'date_equals' => ':Attribute moet een datum zijn gelijk aan :date.',
+    'date_format' => ':Attribute komt niet overeen met het formaat :format.',
+    'decimal' => ':Attribute moet :decimal decimalen bevatten.',
+    'declined' => ':Attribute dient te worden afgewezen.',
+    'declined_if' => ':Attribute dient te worden afgewezen wanneer :other :value is.',
+    'different' => ':Attribute en :other dienen verschillend te zijn.',
+    'digits' => ':Attribute moet :digits cijfers zijn.',
+    'digits_between' => ':Attribute moet tussen :min en :max cijfers zijn.',
+    'dimensions' => ':Attribute heeft een ongeldige grootte.',
+    'distinct' => ':Attribute heeft een dubbele waarde.',
+    'doesnt_end_with' => ':Attribute kan niet eindigen met de volgende waardes: :values.',
+    'doesnt_start_with' => ':Attribute kan niet beginnen met de volgende waardes: :values.',
+    'email' => ':Attribute dient een geldig emailadres te zijn.',
+    'ends_with' => ':Attribute moet eindigen met één van het volgende: :values',
+    'enum' => 'Geselecteerde :attribute is ongeldig.',
+    'exists' => 'Geselecteerde :attribute is ongeldig.',
+    'file' => ':Attribute moet een bestand zijn.',
+    'filled' => ':Attribute veld is verplicht.',
+    'gt' => [
+        'array' => 'Het :attribute veld moet meer dan :value items bevatten.',
+        'file' => 'Het :attribute veld moet groter zijn dan :value kilobytes.',
+        'numeric' => 'Het :attribute veld moet groter zijn dan :value.',
+        'string' => 'Het :attribute veld moet groter zijn dan :value tekens.',
+    ],
+    'gte' => [
+        'array' => 'Het :attribute veld moet :value of meer items bevatten.',
+        'file' => 'Het :attribute veld moet groter of gelijk zijn aan :value kilobytes.',
+        'numeric' => 'Het :attribute veld moet groter of gelijk zijn aan :value.',
+        'string' => 'Het :attribute veld moet groter of gelijk zijn aan :value tekens.',
+    ],
+    'image' => ':Attribute dient een afbeelding te zijn.',
+    'in' => 'Geselecteerde :attribute is ongeldig.',
+    'in_array' => ':Attribute komt niet voor in :other.',
+    'integer' => ':Attribute dient een geheel getal te zijn.',
+    'ip' => ':Attribute dient een geldig IP adres te zijn.',
+    'ipv4' => ':Attribute dient een geldig IPv4 adres te zijn.',
+    'ipv6' => ':Attribute dient een geldig IPv6 adres te zijn..',
+    'json' => ':Attribute moet een geldige JSON string zijn.',
+    'lowercase' => 'De :attribute moet in kleine letters zijn.',
+    'lt' => [
+        'array' => 'Het :attribute veld moet minder dan :value items bevatten.',
+        'file' => 'Het :attribute veld moet kleiner zijn dan :value kilobytes.',
+        'numeric' => 'Het :attribute veld moet kleiner zijn dan :value.',
+        'string' => 'Het :attribute veld moet kleiner zijn dan :value tekens.',
+    ],
+    'lte' => [
+        'array' => 'Het :attribute veld mag maximaal :value items bevatten.',
+        'file' => 'Het :attribute veld moet kleiner of gelijk zijn aan :value kilobytes.',
+        'numeric' => 'Het :attribute veld moet kleiner of gelijk zijn aan :value.',
+        'string' => 'Het :attribute veld moet kleiner of gelijk zijn aan :value tekens.',
+    ],
+    'mac_address' => ':Attribute moet een geldig MAC adres zijn.',
+    'max' => [
+        'array' => ':Attribute mag niet meer dan :max items bevatten.',
+        'file' => ':Attribute mag niet groter zijn dan :max kilobytes.',
+        'numeric' => ':Attribute mag niet groter zijn dan :max.',
+        'string' => ':Attribute mag niet groter zijn dan :max karakters.',
+    ],
+    'max_digits' => 'Het :attribute mag niet meer dan :max cijfers bevatten.',
+    'mimes' => ':Attribute dient een bestand te zijn van het type: :values.',
+    'mimetypes' => ':Attribute dient een bestand te zijn van het type: :values.',
+    'min' => [
+        'array' => ':Attribute dient minimaal :min items te bevatten.',
+        'file' => ':Attribute dient minimaal :min kilobytes te zijn.',
+        'numeric' => ':Attribute dient minimaal :min te zijn.',
+        'string' => ':Attribute dient minimaal :min karakters te bevatten.',
+    ],
+    'min_digits' => 'Het :attribute moet minstens :min cijfers bevatten.',
+    'missing' => ':Attribute mag niet worden meegestuurd',
+    'missing_if' => ':Attribute mag niet worden meegestuurd wanneer :other :value is.',
+    'missing_unless' => ':Attribute mag niet worden meegestuurd behalve als :other :value is.',
+    'missing_with' => ':Attribute mag niet worden meegestuurd wanneer :values bestaat.',
+    'missing_with_all' => ':Attribute mag niet worden meegestuurd wanneer :values meegestuurd wordt.',
+    'multiple_of' => 'Het :attribute moet een veelvoud zijn van :value.',
+    'not_in' => 'Geselecteerde :attribute is ongeldig.',
+    'not_regex' => 'Het :attribute format is ongeldig.',
+    'numeric' => ':Attribute dient een nummer te zijn.',
+    'password' => [
+        'letters' => ':Attribute moet alleen uit letters bestaan.',
+        'mixed' => ':Attribute moet minstens één hoofdletter en één kleine letter bevatten.',
+        'numbers' => ':Attribute moet minstens één nummer bevatten.',
+        'symbols' => ':Attribute moet minstens één symbool bevatten.',
+        'uncompromised' => ':Attribute komt voor in een data lek. Kies een ander :attribute.',
+    ],
+    'present' => ':Attribute dient aanwezig te zijn.',
+    'prohibited' => 'Het :attribute veld is niet toegestaan.',
+    'prohibited_if' => 'Het :attribute veld is niet toegestaan wanneer :other :value is.',
+    'prohibited_unless' => 'Het :attribute veld is niet toegestaan tenzij :other voorkomt in :values.',
+    'prohibits' => 'Het :attribute veld staat niet toe dat :other aanwezig is.',
+    'regex' => 'Het :attribute formaat is ongeldig.',
+    'required' => 'Het :attribute veld is verplicht.',
+    'required_array_keys' => 'Het veld :attribute moet vermeldingen bevatten voor: :values.',
+    'required_if' => 'Het :attribute veld is verplicht wanneer :other is :value.',
+    'required_if_accepted' => 'Het veld :attribute is vereist wanneer :other is geaccepteerd.',
+    'required_unless' => 'Het :attribute veld is verplicht, tenzij :other is in :values.',
+    'required_with' => 'Het :attribute veld is verplicht wanneer :values aanwezig is.',
+    'required_with_all' => 'Het :attribute veld is verplicht wanneer :values aanwezig is.',
+    'required_without' => 'Het :attribute veld is verplicht wanneer :values niet aanwezig is.',
+    'required_without_all' => 'Het :attribute veld is verplicht wanneer geen van :values aanwezig is.',
+    'same' => ':Attribute en :other moeten hetzelfde zijn.',
+    'size' => [
+        'array' => ':Attribute moet :size items bevatten.',
+        'file' => ':Attribute moet :size kilobytes groot zijn.',
+        'numeric' => ':Attribute moet :size zijn.',
+        'string' => ':Attribute moet :size karakters lang zijn.',
+    ],
+    'starts_with' => ':Attribute moet beginnen met één van het volgende: :values',
+    'string' => ':Attribute moet een string zijn.',
+    'timezone' => ':Attribute moet een geldige tijdszone zijn.',
+    'unique' => ':Attribute is al bezet.',
+    'uploaded' => 'Het uploaden van :attribute is mislukt.',
+    'uppercase' => ':Attribute moet in hoofdletters zijn.',
+    'url' => ':Attribute formaat is ongeldig.',
+    'ulid' => ':Attribute moet een valide ULID zijn.',
+    'uuid' => ':Attribute moet een valide UUID zijn.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [],
+
+];

--- a/src/News/Filament/Resources/PostResource.php
+++ b/src/News/Filament/Resources/PostResource.php
@@ -100,7 +100,7 @@ class PostResource extends Resource
                                                         Action::make('generate-slug')
                                                             ->label('Maak automatisch een slug aan de hand van de pagina naam.')
                                                             ->icon('heroicon-s-arrow-path')
-                                                            ->action(fn(Get $get, Set $set, ?string $state) => $set(
+                                                            ->action(fn (Get $get, Set $set, ?string $state) => $set(
                                                                 'slug',
                                                                 Str::slug($get('name'))
                                                             ))
@@ -158,7 +158,7 @@ class PostResource extends Resource
                                                     ->disabled()
                                                     ->relationship('translatedFrom', 'name')
                                                     ->helperText(__('made-cms::cms.resources.post.fields.translated_from.helperText'))
-                                                    ->visible(fn(Get $get) => $get('translated_from_id') !== null),
+                                                    ->visible(fn (Get $get) => $get('translated_from_id') !== null),
 
                                             ]),
 
@@ -231,7 +231,7 @@ class PostResource extends Resource
                                             ->options(
                                                 Post::select(['id', 'name'])
                                                     ->get()
-                                                    ->mapWithKeys(fn($page) => [$page->id => $page->name])
+                                                    ->mapWithKeys(fn ($page) => [$page->id => $page->name])
                                             ),
 
                                     ])
@@ -292,8 +292,8 @@ class PostResource extends Resource
                 TextColumn::make('status')
                     ->label(__('made-cms::cms.resources.page.table.status'))
                     ->badge()
-                    ->color(fn(PublishingStatus $state) => $state->color())
-                    ->formatStateUsing(fn(PublishingStatus $state) => $state->label()),
+                    ->color(fn (PublishingStatus $state) => $state->color())
+                    ->formatStateUsing(fn (PublishingStatus $state) => $state->label()),
 
                 TextColumn::make('translatedFrom.name')
                     ->label('Vertaling van')
@@ -314,7 +314,7 @@ class PostResource extends Resource
                     ->label(__('made-cms::cms.resources.page.filters.locale.label')),
 
                 SelectFilter::make('translated_from_id')
-                    ->options(Post::query()->get()->mapWithKeys(fn($post) => [$post->id => $post->name]))
+                    ->options(Post::query()->get()->mapWithKeys(fn ($post) => [$post->id => $post->name]))
                     ->label('Vertaling van'),
 
                 TrashedFilter::make(),

--- a/src/News/Filament/Resources/PostResource.php
+++ b/src/News/Filament/Resources/PostResource.php
@@ -100,7 +100,7 @@ class PostResource extends Resource
                                                         Action::make('generate-slug')
                                                             ->label('Maak automatisch een slug aan de hand van de pagina naam.')
                                                             ->icon('heroicon-s-arrow-path')
-                                                            ->action(fn (Get $get, Set $set, ?string $state) => $set(
+                                                            ->action(fn(Get $get, Set $set, ?string $state) => $set(
                                                                 'slug',
                                                                 Str::slug($get('name'))
                                                             ))
@@ -116,6 +116,13 @@ class PostResource extends Resource
                                                     ->collection('featured_image')
                                                     ->image()
                                                     ->imageEditor(),
+
+                                                Textarea::make('introduction')
+                                                    ->label(__('made-cms::cms.resources.post.fields.introduction.label'))
+                                                    ->helperText(__('made-cms::cms.resources.post.fields.introduction.helperText'))
+                                                    ->nullable()
+                                                    ->minLength(10)
+                                                    ->maxLength(config('made-cms.content.post.introduction_max_length')),
 
                                             ]),
 
@@ -151,7 +158,7 @@ class PostResource extends Resource
                                                     ->disabled()
                                                     ->relationship('translatedFrom', 'name')
                                                     ->helperText(__('made-cms::cms.resources.post.fields.translated_from.helperText'))
-                                                    ->visible(fn (Get $get) => $get('translated_from_id') !== null),
+                                                    ->visible(fn(Get $get) => $get('translated_from_id') !== null),
 
                                             ]),
 
@@ -224,7 +231,7 @@ class PostResource extends Resource
                                             ->options(
                                                 Post::select(['id', 'name'])
                                                     ->get()
-                                                    ->mapWithKeys(fn ($page) => [$page->id => $page->name])
+                                                    ->mapWithKeys(fn($page) => [$page->id => $page->name])
                                             ),
 
                                     ])
@@ -285,8 +292,8 @@ class PostResource extends Resource
                 TextColumn::make('status')
                     ->label(__('made-cms::cms.resources.page.table.status'))
                     ->badge()
-                    ->color(fn (PublishingStatus $state) => $state->color())
-                    ->formatStateUsing(fn (PublishingStatus $state) => $state->label()),
+                    ->color(fn(PublishingStatus $state) => $state->color())
+                    ->formatStateUsing(fn(PublishingStatus $state) => $state->label()),
 
                 TextColumn::make('translatedFrom.name')
                     ->label('Vertaling van')
@@ -307,7 +314,7 @@ class PostResource extends Resource
                     ->label(__('made-cms::cms.resources.page.filters.locale.label')),
 
                 SelectFilter::make('translated_from_id')
-                    ->options(Post::query()->get()->mapWithKeys(fn ($post) => [$post->id => $post->name]))
+                    ->options(Post::query()->get()->mapWithKeys(fn($post) => [$post->id => $post->name]))
                     ->label('Vertaling van'),
 
                 TrashedFilter::make(),

--- a/src/News/Models/Post.php
+++ b/src/News/Models/Post.php
@@ -38,6 +38,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
  * @property string $name
  * @property string $slug
  * @property Carbon $date
+ * @property string|null $introduction
  * @property PublishingStatus $status
  * @property array $content
  * @property int $created_by
@@ -86,6 +87,7 @@ class Post extends Model implements DefinesCreatedByContract, HasMedia, HasMeta,
         'name',
         'slug',
         'date',
+        'introduction',
         'status',
         'content',
         'created_by',


### PR DESCRIPTION
Adds an introduction field to the posts table and resource.

- This allows for a short summary of each post to be displayed in overviews.
- Configures the maximum length of the introduction text.
- Includes localization for the new field.