### PR TITLE
🔧 Allows configuration of builder selector columns

### DIFF
--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -106,6 +106,8 @@ return [
      * ### Content
      */
     'content' => [
+        'builder_selector_columns' => 1,
+
         'blocks' => [
             /**
              * List of default content stip blocks.

--- a/src/Page/Filament/Resources/PageResource.php
+++ b/src/Page/Filament/Resources/PageResource.php
@@ -208,7 +208,8 @@ class PageResource extends Resource
             ->addActionLabel(__('made-cms::pages.fields.content.add_button'))
             ->collapsible()
             ->collapsed()
-            ->blocks(self::contentStrips(Page::class, $context));
+            ->blocks(self::contentStrips(Page::class, $context))
+            ->blockPickerColumns(config('made-cms.content.builder_selector_columns'));
     }
 
     public static function table(Table $table): Table


### PR DESCRIPTION
Adds a configuration option to control the number of columns
in the block picker within the content builder. This allows
for better layout control and usability when selecting content
blocks.
