### PR TITLE
🔧 Configures content builder selector appearance

### DIFF
--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -106,6 +106,14 @@ return [
      * ### Content
      */
     'content' => [
+        /**
+         * The width for the content builder selector.
+         */
+        'builder_selector_width' => '2xl',
+
+        /**
+         * The amount of columns for the builder selector.
+         */
         'builder_selector_columns' => 1,
 
         'blocks' => [

--- a/src/Page/Filament/Resources/PageResource.php
+++ b/src/Page/Filament/Resources/PageResource.php
@@ -209,7 +209,8 @@ class PageResource extends Resource
             ->collapsible()
             ->collapsed()
             ->blocks(self::contentStrips(Page::class, $context))
-            ->blockPickerColumns(config('made-cms.content.builder_selector_columns'));
+            ->blockPickerColumns(config('made-cms.content.builder_selector_columns'))
+            ->blockPickerWidth(config('made-cms.content.builder_selector_width'));
     }
 
     public static function table(Table $table): Table


### PR DESCRIPTION
Adds configuration options for the content builder selector's width and number of columns.

This allows customization of the content builder's appearance within the Filament admin panel, improving user experience.
