### PR TITLE
🔧 Enables custom panel plugins and navigation

### DIFF
--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -2,6 +2,8 @@
 
 // config for Made/Cms
 
+use Filament\Navigation\NavigationGroup;
+
 return [
 
     'setup' => [
@@ -51,9 +53,29 @@ return [
          */
         'default' => true,
 
+        /**
+         * Add your own resources to the Made CMS panel.
+         */
         'resources' => [],
 
+        /**
+         * Add your own pages to the Made CMS panel.
+         */
         'pages' => [],
+
+        /**
+         * Add your own plugins to the Made CMS panel.
+         */
+        'plugins' => [],
+
+        /**
+         * Add your own navigation_groups to the Made CMS panel.
+         */
+        'navigation_groups' => [
+            NavigationGroup::make()
+                ->label('Test')
+                ->icon('heroicon-o-newspaper'),
+        ],
 
         /**
          * ### Custom link types

--- a/src/Providers/CmsPanelServiceProvider.php
+++ b/src/Providers/CmsPanelServiceProvider.php
@@ -131,6 +131,8 @@ class CmsPanelServiceProvider extends PanelProvider
     {
         return [
             FilamentPeekPlugin::make(),
+
+            ...config('made-cms.panel.plugins', []),
         ];
     }
 
@@ -156,6 +158,8 @@ class CmsPanelServiceProvider extends PanelProvider
             NavigationGroup::make()
                 ->label(fn (): string => __('made-cms::cms.navigation_groups.company'))
                 ->icon('heroicon-o-information-circle'),
+
+            ...config('made-cms.panel.navigation_groups', []),
         ];
     }
 }


### PR DESCRIPTION
Allows users to extend the Made CMS panel by adding their own plugins and navigation groups via the config file.

This change provides a more flexible way to customize the CMS panel.
