### PR TITLE
🔧 Adds configurable rich editor toolbar

### DIFF
--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -230,6 +230,28 @@ return [
          */
         'news' => [],
 
+
+        /**
+         * ### Editor Toolbar buttons
+         */
+        "toolbarButtons" => [
+            "attachFiles",
+            "blockquote",
+            "bold",
+            "bulletList",
+            "codeBlock",
+            "h1",
+            "h2",
+            "h3",
+            "italic",
+            "link",
+            "orderedList",
+            "redo",
+            "strike",
+            "underline",
+            "undo",
+        ],
+
     ],
 
 ];

--- a/src/Filament/Resources/HasRichEditor.php
+++ b/src/Filament/Resources/HasRichEditor.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+trait HasRichEditor {
+
+    public static function toolbarButtons(): array
+    {
+        return config('made-cms.settings.toolbarButtons', []);
+    }
+
+}


### PR DESCRIPTION
Allows customization of the rich editor's toolbar buttons
via the `made-cms.php` config file.

This provides greater flexibility in tailoring the editor
experience to specific content creation needs.
